### PR TITLE
Add simplenamespace io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
+    - export PATH=/home/travis/miniconda2/bin:$PATH
     - conda update --yes conda
 install:
     - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy cython scipy matplotlib scikit-image pytables pandas

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ the command line using either a standard tool::
 Or, better yet, our custom tool ``ddls`` (or ``python -m deepdish.io.ls``)::
 
     $ ddls test.h5
+    /                          dict
     /foo                       array (10, 20) [float64]
     /sub                       dict
     /sub/bar                   'a string' (8) [unicode]

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -396,18 +396,22 @@ def save(path, data, compression='blosc'):
     ``data.flat[1]`` to retrieve it from inside a Numpy array of type
     ``object``.
 
-    Four types of objects get saved natively in HDF5, the rest get serialized
-    automatically.  For most needs, you should be able to stick to the four,
+    Five types of objects get saved natively in HDF5, the rest get serialized
+    automatically.  For most needs, you should be able to stick to the five,
     which are:
 
     * Dictionaries
     * Lists and tuples
     * Basic data types (including strings and None)
     * Numpy arrays
+    * SimpleNamespaces (for Python >= 3.3, but see note below)
 
-    A recommendation is to always convert your data to using only these four
+    A recommendation is to always convert your data to using only these five
     ingredients. That way your data will always be retrievable by any HDF5
     reader. A class that helps you with this is `deepdish.util.Saveable`.
+
+    Note that the SimpleNamespace type will be read in as dictionaries for
+    earlier versions of Python.
 
     This function requires the `PyTables <http://www.pytables.org/>`_ module to
     be installed.

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from deepdish import six
 
-IO_VERSION = 8
+IO_VERSION = 9
 DEEPDISH_IO_PREFIX = 'DEEPDISH_IO'
 DEEPDISH_IO_VERSION_STR = DEEPDISH_IO_PREFIX + '_VERSION'
 DEEPDISH_IO_UNPACK = DEEPDISH_IO_PREFIX + '_DEEPDISH_IO_UNPACK'
@@ -284,9 +284,6 @@ def _load_level(handler, level):
                      DEEPDISH_IO_ROOT_IS_SNS in level._v_attrs):
             val = sns()
             dct = val.__dict__
-        elif level._v_title.startswith('list:'):
-            dct = {}
-            val = []
         else:
             dct = {}
             val = dct
@@ -310,9 +307,10 @@ def _load_level(handler, level):
 
         if level._v_title.startswith('list:'):
             N = int(level._v_title[len('list:'):])
+            lst = []
             for i in range(N):
-                val.append(dct['i{}'.format(i)])
-            return val
+                lst.append(dct['i{}'.format(i)])
+            return lst
         elif level._v_title.startswith('tuple:'):
             N = int(level._v_title[len('tuple:'):])
             lst = []

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -11,7 +11,7 @@ except ImportError:
     _pandas = False
 
 try:
-    from types import SimpleNamespace as sns
+    from types import SimpleNamespace
     _sns = True
 except ImportError:
     _sns = False
@@ -151,10 +151,11 @@ def _save_level(handler, group, level, name=None, filters=None):
             if isinstance(k, six.string_types):
                 _save_level(handler, new_group, v, name=k)
 
-    elif _sns and isinstance(level, sns) and _dict_native_ok(level.__dict__):
+    elif (_sns and isinstance(level, SimpleNamespace) and
+          _dict_native_ok(level.__dict__)):
         # Create a new group in same manner as for dict
-        new_group = handler.create_group(group, name,
-                                         "sns:{}".format(len(level.__dict__)))
+        new_group = handler.create_group(
+            group, name, "SimpleNamespace:{}".format(len(level.__dict__)))
         for k, v in level.__dict__.items():
             if isinstance(k, six.string_types):
                 _save_level(handler, new_group, v, name=k)
@@ -280,9 +281,9 @@ def _load_pickled(level):
 
 def _load_level(handler, level):
     if isinstance(level, tables.Group):
-        if _sns and (level._v_title.startswith('sns:') or
+        if _sns and (level._v_title.startswith('SimpleNamespace:') or
                      DEEPDISH_IO_ROOT_IS_SNS in level._v_attrs):
-            val = sns()
+            val = SimpleNamespace()
             dct = val.__dict__
         else:
             dct = {}
@@ -452,7 +453,8 @@ def save(path, data, compression='blosc'):
             for key, value in data.items():
                 _save_level(h5file, group, value, name=key, filters=filters)
 
-        elif _sns and isinstance(data, sns) and _dict_native_ok(data.__dict__):
+        elif (_sns and isinstance(data, SimpleNamespace) and
+              _dict_native_ok(data.__dict__)):
             group._v_attrs[DEEPDISH_IO_ROOT_IS_SNS] = True
             for key, value in data.__dict__.items():
                 _save_level(h5file, group, value, name=key, filters=filters)

--- a/deepdish/io/ls.py
+++ b/deepdish/io/ls.py
@@ -391,21 +391,6 @@ class ObjectNode(Node):
                            colorize=colorize)
 
 
-class SoftLinkNode(Node):
-    def __init__(self, target):
-        self.target = target
-
-    def info(self, colorize=True, final_level=False):
-        return type_string('link -> {}'.format(self.target),
-                           dtype='SoftLink',
-                           type_color='cyan',
-                           colorize=colorize)
-
-    def __repr__(self):
-        return ('SoftLinkNode(target={})'
-                .format(self.target))
-
-
 def _tree_level(level, raw=False):
     if isinstance(level, tables.Group):
         if _sns and (level._v_title.startswith('sns:') or
@@ -491,9 +476,6 @@ def _tree_level(level, raw=False):
 
             node = NumpyArrayNode(shape, strtype.decode('ascii'))
 
-        return node
-    elif isinstance(level, tables.link.SoftLink):
-        node = SoftLinkNode(level.target)
         return node
     else:
         return Node()

--- a/deepdish/io/ls.py
+++ b/deepdish/io/ls.py
@@ -182,7 +182,7 @@ class DictNode(Node):
               file=sys.stdout):
         if level == 0 and not self.header.get('dd_io_unpack'):
             print_row('', self.info(colorize=colorize,
-                                    final_level=(1 == max_level)),
+                                    final_level=(0 == max_level)),
                       level=level, parent=parent, unpack=False,
                       colorize=colorize, file=file)
         if level < max_level:

--- a/deepdish/io/ls.py
+++ b/deepdish/io/ls.py
@@ -3,7 +3,8 @@ Look inside HDF5 files from the terminal, especially those created by deepdish.
 """
 from __future__ import division, print_function, absolute_import
 from .hdf5io import (DEEPDISH_IO_VERSION_STR, DEEPDISH_IO_PREFIX,
-                     DEEPDISH_IO_UNPACK, IO_VERSION, is_pandas_dataframe)
+                     DEEPDISH_IO_UNPACK, IO_VERSION, _sns,
+                     is_pandas_dataframe)
 import tables
 import numpy as np
 import sys
@@ -80,7 +81,7 @@ def container_info(name, size=None, colorize=True, type_color=None,
         return s
 
     else:
-        # If not abbreviated, then displaly the type in dark gray, since
+        # If not abbreviated, then display the type in dark gray, since
         # the information is already conveyed through the children
         return type_string(name, colorize=colorize, type_color='darkgray')
 
@@ -200,6 +201,39 @@ class DictNode(Node):
     def __repr__(self):
         s = ['{}={}'.format(k, repr(v)) for k, v in self.children.items()]
         return 'DictNode({})'.format(', '.join(s))
+
+
+class SnsNode(Node):
+    def __init__(self):
+        self.children = {}
+        self.header = {}
+
+    def add(self, k, v):
+        self.children[k] = v
+
+    def print(self, level=0, parent='/', colorize=True, max_level=None,
+              file=sys.stdout):
+        if level < max_level:
+            for k in sorted(self.children):
+                v = self.children[k]
+                final = level+1 == max_level
+
+                print_row(k, v.info(colorize=colorize,
+                                    final_level=final), level=level,
+                          parent=parent, unpack=self.header.get('dd_io_unpack'),
+                          colorize=colorize, file=file)
+                v.print(level=level+1, parent='{}{}/'.format(parent, k),
+                        colorize=colorize, max_level=max_level, file=file)
+
+    def info(self, colorize=True, final_level=False):
+        return container_info('SimpleNamespace', size=len(self.children),
+                              colorize=colorize,
+                              type_color='purple',
+                              final_level=final_level)
+
+    def __repr__(self):
+        s = ['{}={}'.format(k, repr(v)) for k, v in self.children.items()]
+        return 'SnsNode({})'.format(', '.join(s))
 
 
 class PandasDataFrameNode(Node):
@@ -375,7 +409,10 @@ class ObjectNode(Node):
 
 def _tree_level(level, raw=False):
     if isinstance(level, tables.Group):
-        node = DictNode()
+        if _sns and level._v_title.startswith('sns:'):
+            node = SnsNode()
+        else:
+            node = DictNode()
 
         for grp in level:
             node.add(grp._v_name, _tree_level(grp, raw=raw))

--- a/deepdish/io/ls.py
+++ b/deepdish/io/ls.py
@@ -393,7 +393,7 @@ class ObjectNode(Node):
 
 def _tree_level(level, raw=False):
     if isinstance(level, tables.Group):
-        if _sns and (level._v_title.startswith('sns:') or
+        if _sns and (level._v_title.startswith('SimpleNamespace:') or
                      DEEPDISH_IO_ROOT_IS_SNS in level._v_attrs):
             node = SimpleNamespaceNode()
         else:

--- a/deepdish/io/ls.py
+++ b/deepdish/io/ls.py
@@ -407,6 +407,21 @@ class ObjectNode(Node):
                            colorize=colorize)
 
 
+class SoftLinkNode(Node):
+    def __init__(self, target):
+        self.target = target
+
+    def info(self, colorize=True, final_level=False):
+        return type_string('link -> {}'.format(self.target),
+                           dtype='SoftLink',
+                           type_color='cyan',
+                           colorize=colorize)
+
+    def __repr__(self):
+        return ('SoftLinkNode(target={})'
+                .format(self.target))
+
+
 def _tree_level(level, raw=False):
     if isinstance(level, tables.Group):
         if _sns and level._v_title.startswith('sns:'):
@@ -491,6 +506,9 @@ def _tree_level(level, raw=False):
 
             node = NumpyArrayNode(shape, strtype.decode('ascii'))
 
+        return node
+    elif isinstance(level, tables.link.SoftLink):
+        node = SoftLinkNode(level.target)
         return node
     else:
         return Node()

--- a/deepdish/tests/test_io.py
+++ b/deepdish/tests/test_io.py
@@ -50,10 +50,10 @@ class TestIO(unittest.TestCase):
             x1 = reconstruct(fn, x)
             assert x == x1
 
-            # ??? This doesn't work - complex numpy arrays work however
-            x = 1.23 + 2.3j
-            x1 = reconstruct(fn, x)
-            assert x == x1
+            # This doesn't work - complex numpy arrays work however
+            #x = 1.23 + 2.3j
+            #x1 = reconstruct(fn, x)
+            #assert x == x1
 
             x = u'this is a string'
             x1 = reconstruct(fn, x)

--- a/deepdish/tests/test_io.py
+++ b/deepdish/tests/test_io.py
@@ -121,63 +121,6 @@ class TestIO(unittest.TestCase):
                 assert d.sub.b == d1.sub.b
                 np.testing.assert_array_equal(d.sub.c, d1.sub.c)
 
-    def test_softlinks_recursion(self):
-        with tmp_filename() as fn:
-            A = np.random.randn(3, 3)
-            df = pd.DataFrame({'int': np.arange(3),
-                               'name': ['zero', 'one', 'two']})
-            AA = 4
-            s = dict(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA,
-                     df=df, df2=df)
-            s['g'].append(s)
-            n = reconstruct(fn, s)
-            assert n['g'][0] is n['A']
-            assert (n['A'] is n['B'] is n['c'] is n['d'] is n['f'] is
-                    n['g'][0] is n['g'][1] is n['g'][2])
-            assert n['g'][3] is n
-            assert n['AA'] == AA == n['h']
-            assert n['df'] is n['df2']
-            assert (n['df'] == df).all().all()
-
-    def test_softlinks_recursion_sns(self):
-        if _sns:
-            with tmp_filename() as fn:
-                A = np.random.randn(3, 3)
-                AA = 4
-                s = sns(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA)
-                s.g.append(s)
-                n = reconstruct(fn, s)
-                assert n.g[0] is n.A
-                assert (n.A is n.B is n.c is n.d is n.f is
-                        n.g[0] is n.g[1] is n.g[2])
-                assert n.g[3] is n
-                assert n.AA == AA == n.h
-
-    def test_pickle_recursion(self):
-        with tmp_filename() as fn:
-            f = {4: 78}
-            f['rec'] = f
-            g = [23.4, f]
-            h = dict(f=f, g=g)
-            h2 = reconstruct(fn, h)
-            assert h2['g'][0] == 23.4
-            assert h2['g'][1] is h2['f']['rec'] is h2['f']
-            assert h2['f'][4] == 78
-
-    def test_list_recursion(self):
-        with tmp_filename() as fn:
-            lst = [1, 3]
-            inlst = ['inside', 'list', lst]
-            inlst.append(inlst)
-            lst.append(lst)
-            lst.append(inlst)
-            lst2 = reconstruct(fn, lst)
-            assert lst2[2] is lst2
-            assert lst2[3][2] is lst2
-            assert lst[3][2] is lst
-            assert lst2[3][3] is lst2[3]
-            assert lst[3][3] is lst[3]
-
     def test_list(self):
         with tmp_filename() as fn:
             x = [100, 'this is a string', np.ones(3), dict(foo=100)]

--- a/deepdish/tests/test_io.py
+++ b/deepdish/tests/test_io.py
@@ -50,10 +50,10 @@ class TestIO(unittest.TestCase):
             x1 = reconstruct(fn, x)
             assert x == x1
 
-            # This doesn't work - complex numpy arrays work however
-            #x = 1.23 + 2.3j
-            #x1 = reconstruct(fn, x)
-            #assert x == x1
+            # ??? This doesn't work - complex numpy arrays work however
+            x = 1.23 + 2.3j
+            x1 = reconstruct(fn, x)
+            assert x == x1
 
             x = u'this is a string'
             x1 = reconstruct(fn, x)
@@ -120,6 +120,63 @@ class TestIO(unittest.TestCase):
                 assert d.sub.a == d1.sub.a
                 assert d.sub.b == d1.sub.b
                 np.testing.assert_array_equal(d.sub.c, d1.sub.c)
+
+    def test_softlinks_recursion(self):
+        with tmp_filename() as fn:
+            A = np.random.randn(3, 3)
+            df = pd.DataFrame({'int': np.arange(3),
+                               'name': ['zero', 'one', 'two']})
+            AA = 4
+            s = dict(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA,
+                     df=df, df2=df)
+            s['g'].append(s)
+            n = reconstruct(fn, s)
+            assert n['g'][0] is n['A']
+            assert (n['A'] is n['B'] is n['c'] is n['d'] is n['f'] is
+                    n['g'][0] is n['g'][1] is n['g'][2])
+            assert n['g'][3] is n
+            assert n['AA'] == AA == n['h']
+            assert n['df'] is n['df2']
+            assert (n['df'] == df).all().all()
+
+    def test_softlinks_recursion_sns(self):
+        if _sns:
+            with tmp_filename() as fn:
+                A = np.random.randn(3, 3)
+                AA = 4
+                s = sns(A=A, B=A, c=A, d=A, f=A, g=[A, A, A], AA=AA, h=AA)
+                s.g.append(s)
+                n = reconstruct(fn, s)
+                assert n.g[0] is n.A
+                assert (n.A is n.B is n.c is n.d is n.f is
+                        n.g[0] is n.g[1] is n.g[2])
+                assert n.g[3] is n
+                assert n.AA == AA == n.h
+
+    def test_pickle_recursion(self):
+        with tmp_filename() as fn:
+            f = {4: 78}
+            f['rec'] = f
+            g = [23.4, f]
+            h = dict(f=f, g=g)
+            h2 = reconstruct(fn, h)
+            assert h2['g'][0] == 23.4
+            assert h2['g'][1] is h2['f']['rec'] is h2['f']
+            assert h2['f'][4] == 78
+
+    def test_list_recursion(self):
+        with tmp_filename() as fn:
+            lst = [1, 3]
+            inlst = ['inside', 'list', lst]
+            inlst.append(inlst)
+            lst.append(lst)
+            lst.append(inlst)
+            lst2 = reconstruct(fn, lst)
+            assert lst2[2] is lst2
+            assert lst2[3][2] is lst2
+            assert lst[3][2] is lst
+            assert lst2[3][3] is lst2[3]
+            assert lst[3][3] is lst[3]
 
     def test_list(self):
         with tmp_filename() as fn:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -72,8 +72,8 @@ SimpleNamespaces, deepdish will seamlessly load them in as dictionaries.
 
 Like dictionaries, SimpleNamespaces are saved as HDF5 groups:
 
->>> from types import SimpleNamespace as sns
->>> d = sns(foo=sns(bar=np.arange(10), baz=np.zeros(3)), qux=np.ones(12))
+>>> from types import SimpleNamespace as NS
+>>> d = NS(foo=NS(bar=np.arange(10), baz=np.zeros(3)), qux=np.ones(12))
 >>> dd.io.save('test.h5', d)
 
 For h5ls, the results are identical to the Dictionary example::

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -12,29 +12,17 @@ Deepdish has a function that converts your Python data type into a native HDF5
 hierarchy. It stores dictionaries, SimpleNamespaces (for versions of Python that
 support them), values, strings and numpy arrays very naturally. It can also
 store lists and tuples, but it's not as natural, so prefer numpy arrays whenever
-possible.
-
-In Python, many names can be bound to the same object. Deepdish accounts for
-this for many objects (dictionaries, lists, numpy arrays, pandas dataframes,
-SimpleNamespaces, etc) by using HDF5 soft links. This means the object itself is
-only written once and that these relationships are preserved upon
-loading. Recursion inside objects is also handled via soft links.
-
-Here's an example saving and HDF5 using :func:`deepdish.io.save`:
+possible. Here's an example saving and HDF5 using :func:`deepdish.io.save`:
 
 >>> import deepdish as dd
->>> ones = np.ones((5, 4, 3))
->>> d = {'foo': np.arange(10), 'bar': ones, 'baz': ones}
+>>> d = {'foo': np.arange(10), 'bar': np.ones((5, 4, 3))}
 >>> dd.io.save('test.h5', d)
 
 It will try its best to save it in a way native to HDF5::
 
     $ h5ls test.h5
     bar                      Dataset {5, 4, 3}
-    baz                      Soft Link {/bar}
     foo                      Dataset {10}
-
-Notice that the `ones` 3D array was only written once.
 
 We also offer our own version of ``h5ls`` that works really well with deepdish
 saved HDF5 files::
@@ -42,18 +30,12 @@ saved HDF5 files::
     $ ddls test.h5
     /                          dict
     /bar                       array (5, 4, 3) [float64]
-    /baz                       link -> /bar [SoftLink]
     /foo                       array (10,) [int64]
 
 We can now reconstruct the dictionary from the file using
 :func:`deepdish.io.load`:
 
 >>> d = dd.io.load('test.h5')
-
-Verify that ``d['bar']`` and ``d['baz']`` refer to the same object:
-
->>> d['bar'] is d['baz']
-True
 
 Dictionaries
 ------------
@@ -183,7 +165,7 @@ attributes::
        [CLASS := 'GROUP',
         TITLE := 'nonetype:',
         VERSION := '1.0']
-        
+
 Note that these are still somewhat awkwardly stored, so always prefer using
 numpy arrays to store numeric values.
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -65,7 +65,7 @@ SimpleNamespaces
 
 SimpleNamespaces work almost identically to dictionaries and are available in
 Python 3.3 and later. Note that for versions of Python that do not support
-SimpleNamespaces, deepdish will seemlessly load them in as dictionaries.
+SimpleNamespaces, deepdish will seamlessly load them in as dictionaries.
 
 Like dictionaries, SimpleNamespaces are saved as HDF5 groups:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -9,10 +9,10 @@ compatible between Python 2 and 3, and the files cannot be easily inspected or
 shared with other programming languages.
 
 Deepdish has a function that converts your Python data type into a native HDF5
-hierarchy. It stores dictionaries, values, strings and numpy arrays very
-naturally. It can also store lists and tuples, but it's not as natural, so
-prefer numpy arrays whenever possible. Here's an example saving and HDF5 using
-:func:`deepdish.io.save`:
+hierarchy. It stores dictionaries, SimpleNamespaces (for versions of Python that
+support them), values, strings and numpy arrays very naturally. It can also
+store lists and tuples, but it's not as natural, so prefer numpy arrays whenever
+possible. Here's an example saving and HDF5 using :func:`deepdish.io.save`:
 
 >>> import deepdish as dd
 >>> d = {'foo': np.arange(10), 'bar': np.ones((5, 4, 3))}
@@ -59,6 +59,46 @@ Again, we can use the deepdish tool for better inspection::
     /foo/bar                   array (10,) [int64]
     /foo/baz                   array (3,) [float64]
     /qux                       array (12,) [float64] 
+
+SimpleNamespaces
+----------------
+
+SimpleNamespaces work almost identically to dictionaries and are available in
+Python 3.3 and later. Note that for versions of Python that do not support
+SimpleNamespaces, deepdish will seemlessly load them in as dictionaries.
+
+Like dictionaries, SimpleNamespaces are saved as HDF5 groups:
+
+>>> from types import SimpleNamespace as sns
+>>> d = sns(foo=sns(bar=np.arange(10), baz=np.zeros(3)), qux=np.ones(12))
+>>> dd.io.save('test.h5', d)
+
+For h5ls, the results are identical to the Dictionary example::
+
+    $ h5ls -r test.h5
+    /                        Group
+    /foo                     Group
+    /foo/bar                 Dataset {10}
+    /foo/baz                 Dataset {3}
+    /qux                     Dataset {12}
+
+Again, we can use the deepdish tool for better inspection. For a version of
+Python that supports SimpleNamespaces::
+
+    $ ddls test.h5
+    /foo                       SimpleNamespace
+    /foo/bar                   array (10,) [int64]
+    /foo/baz                   array (3,) [float64]
+    /qux                       array (12,) [float64]
+
+For a version of Python that doesn't support SimpleNamespaces, dictionaries are
+used::
+
+    $ ddls test.h5
+    /foo                       dict
+    /foo/bar                   array (10,) [int64]
+    /foo/baz                   array (3,) [float64]
+    /qux                       array (12,) [float64]
 
 Numpy arrays
 ------------


### PR DESCRIPTION
This PR adds native save/load of Python SimpleNamespace objects to deepdish. The implementation is such that older versions of Python (that do not support SimpleNamespace types) will seamlessly load them as dictionaries. The current version of deepdish supports the SimpleNamespaces via pickling, which has obvious downsides.

Our group uses dictionaries and SimpleNamespaces very often in our work: dictionaries when the keys are variables, SimpleNamespaces when the keys are fixed.

From "The Zen of Python": Namespaces are one honking great idea -- let's do more of those!
