### PR TITLE
add soft links to save shared objects just once and support recursion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,6 @@ the command line using either a standard tool::
 Or, better yet, our custom tool ``ddls`` (or ``python -m deepdish.io.ls``)::
 
     $ ddls test.h5
-    /                          dict
     /foo                       array (10, 20) [float64]
     /sub                       dict
     /sub/bar                   'a string' (8) [unicode]

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from deepdish import six
 
-IO_VERSION = 9
+IO_VERSION = 10
 DEEPDISH_IO_PREFIX = 'DEEPDISH_IO'
 DEEPDISH_IO_VERSION_STR = DEEPDISH_IO_PREFIX + '_VERSION'
 DEEPDISH_IO_UNPACK = DEEPDISH_IO_PREFIX + '_DEEPDISH_IO_UNPACK'
@@ -139,7 +139,28 @@ def _save_pickled(handler, group, level, name=None):
     node.append(level)
 
 
-def _save_level(handler, group, level, name=None, filters=None):
+def _is_linkable(level):
+    if isinstance(level, ATTR_TYPES):
+        return False
+    return True
+
+
+def _save_level(handler, group, level, name=None, filters=None, idtable=None):
+    _id = id(level)
+    try:
+        oldpath = idtable[_id]
+    except KeyError:
+        if _is_linkable(level):
+            # store path to object:
+            if group._v_pathname.endswith('/'):
+                idtable[_id] = '{}{}'.format(group._v_pathname, name)
+            else:
+                idtable[_id] = '{}/{}'.format(group._v_pathname, name)
+    else:
+        # object already saved, so create soft link to it:
+        handler.create_soft_link(group, name, target=oldpath)
+        return
+
     if isinstance(level, ForcePickle):
         _save_pickled(handler, group, level, name=name)
 
@@ -149,7 +170,7 @@ def _save_level(handler, group, level, name=None, filters=None):
                                          "dict:{}".format(len(level)))
         for k, v in level.items():
             if isinstance(k, six.string_types):
-                _save_level(handler, new_group, v, name=k)
+                _save_level(handler, new_group, v, name=k, idtable=idtable)
 
     elif (_sns and isinstance(level, SimpleNamespace) and
           _dict_native_ok(level.__dict__)):
@@ -158,7 +179,7 @@ def _save_level(handler, group, level, name=None, filters=None):
             group, name, "SimpleNamespace:{}".format(len(level.__dict__)))
         for k, v in level.__dict__.items():
             if isinstance(k, six.string_types):
-                _save_level(handler, new_group, v, name=k)
+                _save_level(handler, new_group, v, name=k, idtable=idtable)
 
     elif isinstance(level, list) and len(level) < 256:
         # Lists can contain other dictionaries and numpy arrays, so we don't
@@ -169,7 +190,8 @@ def _save_level(handler, group, level, name=None, filters=None):
 
         for i, entry in enumerate(level):
             level_name = 'i{}'.format(i)
-            _save_level(handler, new_group, entry, name=level_name)
+            _save_level(handler, new_group, entry,
+                        name=level_name, idtable=idtable)
 
     elif isinstance(level, tuple) and len(level) < 256:
         # Lists can contain other dictionaries and numpy arrays, so we don't
@@ -180,7 +202,8 @@ def _save_level(handler, group, level, name=None, filters=None):
 
         for i, entry in enumerate(level):
             level_name = 'i{}'.format(i)
-            _save_level(handler, new_group, entry, name=level_name)
+            _save_level(handler, new_group, entry, name=level_name,
+                        idtable=idtable)
 
     elif isinstance(level, np.ndarray):
         _save_ndarray(handler, group, name, level, filters=filters)
@@ -238,19 +261,19 @@ def _save_level(handler, group, level, name=None, filters=None):
         _save_pickled(handler, group, level, name=name)
 
 
-def _load_specific_level(handler, grp, path, sel=None):
+def _load_specific_level(handler, grp, path, sel=None, pathtable=None):
     if path == '':
         if sel is not None:
             return _load_sliced_level(handler, grp, sel)
         else:
-            return _load_level(handler, grp)
+            return _load_level(handler, grp, pathtable)
     vv = path.split('/', 1)
     if len(vv) == 1:
         if hasattr(grp, vv[0]):
             if sel is not None:
                 return _load_sliced_level(handler, getattr(grp, vv[0]), sel)
             else:
-                return _load_level(handler, getattr(grp, vv[0]))
+                return _load_level(handler, getattr(grp, vv[0]), pathtable)
         elif hasattr(grp, '_v_attrs') and vv[0] in grp._v_attrs:
             if sel is not None:
                 raise ValueError("Cannot slice this type")
@@ -263,11 +286,12 @@ def _load_specific_level(handler, grp, path, sel=None):
     else:
         level, rest = vv
         if level == '':
-            return _load_specific_level(handler, grp.root, rest, sel=sel)
+            return _load_specific_level(handler, grp.root, rest, sel=sel,
+                                        pathtable=pathtable)
         else:
             if hasattr(grp, level):
                 return _load_specific_level(handler, getattr(grp, level),
-                                            rest, sel=sel)
+                                            rest, sel=sel, pathtable=pathtable)
             else:
                 raise ValueError('Undefined group "{}"'.format(level))
 
@@ -279,19 +303,25 @@ def _load_pickled(level):
         return level[0]
 
 
-def _load_level(handler, level):
+def _load_level1(handler, level, pathtable, pathname):
     if isinstance(level, tables.Group):
         if _sns and (level._v_title.startswith('SimpleNamespace:') or
                      DEEPDISH_IO_ROOT_IS_SNS in level._v_attrs):
             val = SimpleNamespace()
             dct = val.__dict__
+        elif level._v_title.startswith('list:'):
+            dct = {}
+            val = []
         else:
             dct = {}
             val = dct
+        # in case of recursion, object needs to be put in pathtable
+        # before trying to fully load it
+        pathtable[pathname] = val
 
         # Load sub-groups
         for grp in level:
-            lev = _load_level(handler, grp)
+            lev = _load_level(handler, grp, pathtable)
             n = grp._v_name
             # Check if it's a complicated pair or a string-value pair
             if n.startswith('__pair'):
@@ -308,10 +338,9 @@ def _load_level(handler, level):
 
         if level._v_title.startswith('list:'):
             N = int(level._v_title[len('list:'):])
-            lst = []
             for i in range(N):
-                lst.append(dct['i{}'.format(i)])
-            return lst
+                val.append(dct['i{}'.format(i)])
+            return val
         elif level._v_title.startswith('tuple:'):
             N = int(level._v_title[len('tuple:'):])
             lst = []
@@ -375,7 +404,29 @@ def _load_level(handler, level):
         return level[:]
 
 
+def _load_level(handler, level, pathtable):
+    if isinstance(level, tables.link.SoftLink):
+        # this is a link, so see if target is already loaded, return it
+        pathname = level.target
+        node = level()
+    else:
+        # not a link, but it might be a target that's already been
+        # loaded ... if so, return it
+        pathname = level._v_pathname
+        node = level
+    try:
+        return pathtable[pathname]
+    except KeyError:
+        pathtable[pathname] = _load_level1(handler, node, pathtable,
+                                           pathname)
+        return pathtable[pathname]
+
+
 def _load_sliced_level(handler, level, sel):
+    if isinstance(level, tables.link.SoftLink):
+        # this is a link; get target:
+        level = level()
+
     if isinstance(level, tables.VLArray):
         if level.shape == (1,):
             return _load_pickled(level)
@@ -447,20 +498,26 @@ def save(path, data, compression='blosc'):
         # If the data is a dictionary, put it flatly in the root
         group = h5file.root
         group._v_attrs[DEEPDISH_IO_VERSION_STR] = IO_VERSION
+        idtable = {}  # dict to keep track of objects already saved
         # Sparse matrices match isinstance(data, dict), so we'll have to be
         # more strict with the type checking
         if type(data) == type({}) and _dict_native_ok(data):
+            idtable[id(data)] = '/'
             for key, value in data.items():
-                _save_level(h5file, group, value, name=key, filters=filters)
+                _save_level(h5file, group, value, name=key,
+                            filters=filters, idtable=idtable)
 
         elif (_sns and isinstance(data, SimpleNamespace) and
               _dict_native_ok(data.__dict__)):
+            idtable[id(data)] = '/'
             group._v_attrs[DEEPDISH_IO_ROOT_IS_SNS] = True
             for key, value in data.__dict__.items():
-                _save_level(h5file, group, value, name=key, filters=filters)
+                _save_level(h5file, group, value, name=key,
+                            filters=filters, idtable=idtable)
 
         else:
-            _save_level(h5file, group, data, name='data', filters=filters)
+            _save_level(h5file, group, data, name='data',
+                        filters=filters, idtable=idtable)
             # Mark this to automatically unpack when loaded
             group._v_attrs[DEEPDISH_IO_UNPACK] = True
 
@@ -501,8 +558,10 @@ def load(path, group=None, sel=None, unpack=False):
         path = path.name
 
     with tables.open_file(path, mode='r') as h5file:
+        pathtable = {}  # dict to keep track of objects already loaded
         if group is not None:
-            data = _load_specific_level(h5file, h5file, group, sel=sel)
+            data = _load_specific_level(h5file, h5file, group, sel=sel,
+                                        pathtable=pathtable)
         else:
             grp = h5file.root
             auto_unpack = (DEEPDISH_IO_UNPACK in grp._v_attrs and
@@ -510,13 +569,14 @@ def load(path, group=None, sel=None, unpack=False):
             do_unpack = unpack or auto_unpack
             if do_unpack and len(grp._v_children) == 1:
                 name = next(iter(grp._v_children))
-                data = _load_specific_level(h5file, grp, name, sel=sel)
+                data = _load_specific_level(h5file, grp, name, sel=sel,
+                                            pathtable=pathtable)
                 do_unpack = False
             elif sel is not None:
                 raise ValueError("Must specify group with `sel` unless it "
                                  "automatically unpacks")
             else:
-                data = _load_level(h5file, grp)
+                data = _load_level(h5file, grp, pathtable)
 
             if DEEPDISH_IO_VERSION_STR in grp._v_attrs:
                 v = grp._v_attrs[DEEPDISH_IO_VERSION_STR]


### PR DESCRIPTION
This PR adds soft links to deepdish. Primary, this means that a shared object will be written to the disk just once no matter how many names or other objects refer to it. These relationships are maintained upon load. Also allows for recursion.

A common use case for us is the saving of time vectors for accelerometer data or analysis data. Often, the time vectors are all the same, but sometimes they are all different. Similarly for frequency vectors in frequency response analysis. Also, sometimes it's handy to have a shortcut link (not unlike a file-system link) from within one dictionary to another "common data" dictionary in a large data structure. The Softlinks capability in HDF5 make adding this feature to deepdish almost trivial. :smile:

For example:

    import numpy as np
    import deepdish as dd
    A = np.random.randn(3, 3)
    d = dict(A=A, B=A)   # two objects point to same matrix
    d['C'] = d           # add a recursive member
    dd.io.save('test.h5', d)
    d2 = dd.io.load('test.h5')

From within ipython:

    In [2]: d2['B'] is d2['A']
    Out[2]: True

    In [3]: d2['C'] is d2
    Out[3]: True

Here is a `ddls` view of the file:

    $ ddls test.h5
    /A                         array (3, 3) [float64]
    /B                         link -> /A [SoftLink]
    /C                         link -> / [SoftLink]

