### PR TITLE
Fix AttributeError for Pandas version 0.24.0 or greater

### DIFF
--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -7,6 +7,7 @@ from scipy import sparse
 from deepdish import conf
 try:
     import pandas as pd
+    pd.io.pytables._tables()
     _pandas = True
 except ImportError:
     _pandas = False


### PR DESCRIPTION
Added a simple fix to an `AttributeError` that is raised when saving Pandas data types if the user has Pandas version 0.24.0 or greater.

Resolves #36.