### PR TITLE
Remove pd.Panel references

### DIFF
--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -104,7 +104,7 @@ def _get_compression_filters(compression='default'):
         try:
             ff = tables.Filters(complevel=level, complib=compression,
                                 shuffle=True)
-        except Exception: 
+        except Exception:
             warnings.warn(("(deepdish.io.save) Missing compression method {}: "
                            "no compression will be used.").format(compression))
             ff = None

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -104,7 +104,7 @@ def _get_compression_filters(compression='default'):
         try:
             ff = tables.Filters(complevel=level, complib=compression,
                                 shuffle=True)
-        except Exception:
+        except Exception: 
             warnings.warn(("(deepdish.io.save) Missing compression method {}: "
                            "no compression will be used.").format(compression))
             ff = None
@@ -249,7 +249,7 @@ def _save_level(handler, group, level, name=None, filters=None, idtable=None):
     elif isinstance(level, np.ndarray):
         _save_ndarray(handler, group, name, level, filters=filters)
 
-    elif _pandas and isinstance(level, (pd.DataFrame, pd.Series, pd.Panel)):
+    elif _pandas and isinstance(level, (pd.DataFrame, pd.Series)):
         store = _HDFStoreWithHandle(handler)
         store.put(group._v_pathname + '/' + name, level)
 

--- a/deepdish/tests/test_io.py
+++ b/deepdish/tests/test_io.py
@@ -369,16 +369,6 @@ class TestIO(unittest.TestCase):
             s1 = reconstruct(fn, s)
             assert (s == s1).all()
 
-    def test_pandas_panel(self):
-        rs = np.random.RandomState(1234)
-        with tmp_filename() as fn:
-            wp = pd.Panel(rs.randn(2, 5, 4), items=['Item1', 'Item2'],
-                          major_axis=pd.date_range('1/1/2000', periods=5),
-                          minor_axis=['A', 'B', 'C', 'D'])
-            wp1 = reconstruct(fn, wp)
-            # Not sure how to test equality, so we'll just do this
-            assert (wp.values == wp1.values).all()
-
     def test_compression_true(self):
         rs = np.random.RandomState(1234)
         with tmp_filename() as fn:


### PR DESCRIPTION
As noted in #45 Pandas has removed `pd.Panel` making deepdish incompatible with Pandas >=1.2.0. `pd.Panel` is deprecated since Pandas 0.20.0, therefore I have removed the references to `pd.Panel` in deepdish.