### PR TITLE
Update core.py and hdf5io.py to be compatible with latest version of numpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build
 *.pyc
 *.c
 *.so
+*.egg-info/
 
 # OS or Editor folders
 .DS_Store

--- a/deepdish/core.py
+++ b/deepdish/core.py
@@ -5,7 +5,7 @@ import numpy as np
 import itertools as itr
 import sys
 from contextlib import contextmanager
-warnings.simplefilter("ignore", np.ComplexWarning)
+warnings.simplefilter("ignore", np.exceptions.ComplexWarning)
 
 _is_verbose = False
 _is_silent = False

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -112,7 +112,7 @@ def _get_compression_filters(compression='default'):
 
 
 def _save_ndarray(handler, group, name, x, filters=None):
-    if np.issubdtype(x.dtype, np.unicode_):
+    if np.issubdtype(x.dtype, np.str_):
         # Convert unicode strings to pure byte arrays
         strtype = b'unicode'
         itemsize = x.itemsize // 4

--- a/deepdish/io/hdf5io.py
+++ b/deepdish/io/hdf5io.py
@@ -118,7 +118,7 @@ def _save_ndarray(handler, group, name, x, filters=None):
         itemsize = x.itemsize // 4
         atom = tables.UInt8Atom()
         x = x.view(dtype=np.uint8)
-    elif np.issubdtype(x.dtype, np.string_):
+    elif np.issubdtype(x.dtype, np.bytes_):
         strtype = b'ascii'
         itemsize = x.itemsize
         atom = tables.StringAtom(itemsize)


### PR DESCRIPTION
The changes address the following errors:

```
AttributeError: module 'numpy' has no attribute 'ComplexWarning'
```

```
AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.
```

```
AttributeError: `np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
```